### PR TITLE
Added docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu 
+
+RUN apt-get update && apt-get dist-upgrade -y
+
+RUN apt-get install curl wget build-essential -y
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+RUN apt-get install nodejs -y
+
+WORKDIR /app
+ADD . /app/
+
+RUN npm install
+
+ENTRYPOINT npm start
+
+EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # nst-streaming
 NST Manager Node Streaming
+
+
+## Docker
+
+* Clone this repo.
+* `docker build -t nst-streaming .`
+* `docker run --name nst-streaming --restart unless-stopped -p 3000:3000 -d nst-streaming`


### PR DESCRIPTION
This adds `docker` support by adding a small `Dockerfile` so that you can containerize the server.

I also added instructions to the README on how to build and run the container.

This worked out of the box for me, the only issue I saw was that I needed to add the IP of my server to the NST app as it didn't find the server upon discovery. But that could just be the way my network is setup.